### PR TITLE
Make curl command and variables configurable.

### DIFF
--- a/plugin/dict.vim
+++ b/plugin/dict.vim
@@ -22,6 +22,14 @@ endif
 
 let g:loaded_dict = 1
 
+if !exists("g:dict_curl_command")
+    let g:dict_curl_command = "curl"
+endif
+
+if !exists("g:dict_curl_options")
+    let g:dict_curl_options = "-s --connect-timeout 5"
+endif
+
 if !exists("g:dict_hosts")
     let g:dict_hosts = [["dict.org", ["all"]]]
 endif
@@ -48,7 +56,7 @@ fun! s:dict(...)
     set buftype=nofile
     for host in g:dict_hosts
         for db in host[1]
-            silent! exe "noautocmd r! curl -s --connect-timeout 5 dict://" . host[0] . "/d:" . word . ":" . db
+            silent! exe "noautocmd r!" g:dict_curl_command g:dict_curl_options "dict://" . host[0] . "/d:" . word . ":" . db
         endfor
     endfor
     silent! exe "%s///g"
@@ -75,7 +83,7 @@ fun! s:dict_show_db()
         silent! exe "normal I--------------------------------------------------------------------------------\r"
         silent! exe "normal IServer: " . host[0] . "\r"
         silent! exe "normal I--------------------------------------------------------------------------------\r"
-        silent! exe "noautocmd r! curl -s --connect-timeout 5 dict://" . host[0] . "/show:db"
+        silent! exe "noautocmd r!" g:dict_curl_command g:dict_curl_options "dict://" . host[0] . "/show:db"
     endfor
     silent! exe "%s///g"
     silent! exe "%s/^110 //g"


### PR DESCRIPTION
Thanks for this really helpful plugin! At work, I'm behind a proxy / firewall, so I need to pass additional options to curl. This patch allows to do this without directly modifying the script. Keep up the good work!

-- regards, ingo

Introduce `g:dict_curl_command` and `g:dict_curl`_options to allow for customization. For example, without direct access to the Internet, I need to add `--socks5 socks-server` (because curl doesn't pick up the `http_proxy` environment variable when using the dict protocol).
Some users may not have the curl command on their PATH, so having that configurable is helpful, too. Note that I didn't use `shellescape()` on it, because that function isn't available in Vim 7.0/1, the default doesn't require it, and users customizing it can add that themselves.
